### PR TITLE
PR: Rename binaries, update scripts and Rust version

### DIFF
--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -40,3 +40,7 @@ solana-test-validator = { path = "../test-validator", version = "=1.14.20" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[[bin]]
+name = "sonoma-bench-tps"
+path = "src/main.rs"

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -18,7 +18,7 @@
 if [[ -n $RUST_STABLE_VERSION ]]; then
   stable_version="$RUST_STABLE_VERSION"
 else
-  stable_version=1.67.0
+  stable_version=1.70.0
 fi
 
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then

--- a/dos/Cargo.toml
+++ b/dos/Cargo.toml
@@ -37,3 +37,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dev-dependencies]
 serial_test = "0.8.0"
 solana-local-cluster = { path = "../local-cluster", version = "=1.14.20" }
+
+[[bin]]
+name = "sonoma-dos"
+path = "src/main.rs"

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -32,7 +32,7 @@ crate-type = ["lib"]
 name = "solana_faucet"
 
 [[bin]]
-name = "solana-faucet"
+name = "sonoma-faucet"
 path = "src/bin/faucet.rs"
 
 [package.metadata.docs.rs]

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -28,7 +28,7 @@ solana-vote-program = { path = "../programs/vote", version = "=1.14.20" }
 tempfile = "3.4.0"
 
 [[bin]]
-name = "solana-genesis"
+name = "sonoma-genesis"
 path = "src/main.rs"
 
 [lib]

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -65,7 +65,7 @@ name = "crds_gossip_pull"
 name = "crds_shards"
 
 [[bin]]
-name = "solana-gossip"
+name = "sonoma-gossip"
 path = "src/main.rs"
 
 [package.metadata.docs.rs]

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -50,3 +50,7 @@ signal-hook = "0.3.14"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[[bin]]
+name = "sonoma-ledger-tool"
+path = "src/main.rs"

--- a/log-analyzer/Cargo.toml
+++ b/log-analyzer/Cargo.toml
@@ -18,7 +18,7 @@ solana-logger = { path = "../logger", version = "=1.14.20" }
 solana-version = { path = "../version", version = "=1.14.20" }
 
 [[bin]]
-name = "solana-log-analyzer"
+name = "sonoma-log-analyzer"
 path = "src/main.rs"
 
 [package.metadata.docs.rs]

--- a/net-shaper/Cargo.toml
+++ b/net-shaper/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1.0.81"
 solana-logger = { path = "../logger", version = "=1.14.20" }
 
 [[bin]]
-name = "solana-net-shaper"
+name = "sonoma-net-shaper"
 path = "src/main.rs"
 
 [package.metadata.docs.rs]

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -148,6 +148,10 @@ for bin in "${BINS[@]}"; do
   cp -fv "target/$buildVariant/$bin" "$installDir"/bin
 done
 
+# Rename validator and test-validator bins
+mv "$installDir/bin/solana-validator" "$installDir/bin/sonoma-validator"
+mv "$installDir/bin/solana-test-validator" "$installDir/bin/sonoma-test-validator"
+
 if [[ -d target/perf-libs ]]; then
   cp -a target/perf-libs "$installDir"/bin/perf-libs
 fi

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -84,20 +84,20 @@ if [[ $CI_OS_NAME = windows ]]; then
     cargo-test-sbf
     sonoma
     sonoma-keygen
-    solana-stake-accounts
+    sonoma-stake-accounts
     solana-test-validator
-    solana-tokens
+    sonoma-tokens
   )
 else
   ./fetch-perf-libs.sh
 
   BINS=(
     sonoma
-    solana-bench-tps
+    sonoma-bench-tps
     sonoma-faucet
     sonoma-gossip
     sonoma-keygen
-    solana-ledger-tool
+    sonoma-ledger-tool
     sonoma-log-analyzer
     sonoma-net-shaper
     sonoma-sys-tuner
@@ -112,11 +112,11 @@ else
       cargo-build-sbf
       cargo-test-bpf
       cargo-test-sbf
-      solana-dos
-      solana-stake-accounts
+      sonoma-dos
+      sonoma-stake-accounts
       solana-test-validator
-      solana-tokens
-      solana-watchtower
+      sonoma-tokens
+      sonoma-watchtower
     )
   fi
 

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -83,8 +83,6 @@ if [[ $CI_OS_NAME = windows ]]; then
     cargo-test-bpf
     cargo-test-sbf
     sonoma
-    solana-install
-    solana-install-init
     sonoma-keygen
     solana-stake-accounts
     solana-test-validator
@@ -96,14 +94,13 @@ else
   BINS=(
     sonoma
     solana-bench-tps
-    solana-faucet
-    solana-gossip
-    solana-install
+    sonoma-faucet
+    sonoma-gossip
     sonoma-keygen
     solana-ledger-tool
-    solana-log-analyzer
-    solana-net-shaper
-    solana-sys-tuner
+    sonoma-log-analyzer
+    sonoma-net-shaper
+    sonoma-sys-tuner
     solana-validator
     rbpf-cli
   )
@@ -116,7 +113,6 @@ else
       cargo-test-bpf
       cargo-test-sbf
       solana-dos
-      solana-install-init
       solana-stake-accounts
       solana-test-validator
       solana-tokens
@@ -126,7 +122,7 @@ else
 
   #XXX: Ensure `solana-genesis` is built LAST!
   # See https://github.com/solana-labs/solana/issues/5826
-  BINS+=(solana-genesis)
+  BINS+=(sonoma-genesis)
 fi
 
 binArgs=()

--- a/scripts/sonoma-install.sh
+++ b/scripts/sonoma-install.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Checking the operating system and architecture
+if [[ "$(uname)" != "Linux" || "$(uname -m)" != "x86_64" ]]; then
+  echo "This script is only supported on Linux x86_64"
+  exit 1
+fi
+
+# Checking installed dependencies
+if ! command -v curl &> /dev/null; then
+  echo "curl is required but not installed. Please install curl"
+  exit 1
+fi
+
+# Archive name
+archName="sonoma-x86_64-unknown-linux-gnu.tar.bz2"
+
+# Creating a temporary directory
+tempDir="$(mktemp -d)"
+
+# Downloading and unpacking the Sonoma CLI Binary Archive
+sonomaURL="https://github.com/convowork1/sonoma/raw/master/bin/$archName"
+
+if curl -LJO $sonomaURL && tar jxf $archName -C "$tempDir"; then
+    rm $archName
+else
+    echo "Failed to download and unpack Sonoma CLI Binary Archive"
+    rm -rf "$tempDir"
+    exit 1
+fi
+
+# Defining the installation directory
+installDir="$HOME/.local/share/sonoma/install/active_release/bin"  
+
+# Copying the Sonoma CLI binary to the installation directory
+mkdir -p "$installDir"
+cp -R "$tempDir"/* "$installDir"
+
+# Set the config
+devnet="http://3.74.241.65:8899"
+"$installDir/sonoma" config set --url $devnet >  /dev/null 2>&1
+
+rm -rf "$tempDir"
+
+# Check for the presence of .bash_profile
+if [ -f "$HOME/.bash_profile" ]; then
+    # Add the bin path to .bash_profile
+    if ! grep -q "$installDir" "$HOME/.bash_profile"; then
+        echo -e "export PATH=\"$installDir:\$PATH\"" >> "$HOME/.bash_profile"
+        echo "Bin path successfully added to .bash_profile"
+    else
+        echo "Bin path already exists in .bash_profile"
+    fi
+# Check for the presence of .profile
+elif [ -f "$HOME/.profile" ]; then
+    # Add the bin path to .profile
+    if ! grep -q "$installDir" "$HOME/.profile"; then
+        echo -e "\nexport PATH=\"$installDir:\$PATH\"" >> "$HOME/.profile"
+        echo "Bin path successfully added to .profile"
+    else
+        echo "Bin path already exists in .profile"
+    fi
+else
+    echo "Neither .profile nor .bash_profile found"
+    echo "Please update your PATH environment variable to include the sonoma programs:"
+    echo "Use 'export PATH=\"$installDir:\$PATH\"'"
+fi
+
+source ~/.profile
+
+echo "Sonoma CLI has been installed successfully"
+echo "You can now use 'sonoma' command in your terminal"

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -23,3 +23,7 @@ solana-runtime = { path = "../runtime", version = "=1.14.20" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[[bin]]
+name = "sonoma-stake-accounts"
+path = "src/main.rs"

--- a/sys-tuner/Cargo.toml
+++ b/sys-tuner/Cargo.toml
@@ -27,7 +27,7 @@ sysctl = "0.4.4"
 name = "solana_sys_tuner"
 
 [[bin]]
-name = "solana-sys-tuner"
+name = "sonoma-sys-tuner"
 path = "src/main.rs"
 
 [package.metadata.docs.rs]

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -37,3 +37,7 @@ bincode = "1.3.3"
 solana-logger = { path = "../logger", version = "=1.14.20" }
 solana-streamer = { path = "../streamer", version = "=1.14.20" }
 solana-test-validator = { path = "../test-validator", version = "=1.14.20" }
+
+[[bin]]
+name = "sonoma-tokens"
+path = "src/main.rs"

--- a/watchtower/Cargo.toml
+++ b/watchtower/Cargo.toml
@@ -25,3 +25,7 @@ solana-version = { path = "../version", version = "=1.14.20" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[[bin]]
+name = "sonoma-watchtower"
+path = "src/main.rs"


### PR DESCRIPTION
In this pull request, the following changes have been made:

- Renamed binaries to Sonoma.
- Updated _cargo-install-all.sh_ - the project build script.
- Added the _sonoma-install.sh_ script for users to download the required binaries.
- Updated Rust version to 1.70 in _rust-version.sh_.